### PR TITLE
Fix name of Horse64 Root concept (#636)

### DIFF
--- a/concepts/horse64-root.scroll
+++ b/concepts/horse64-root.scroll
@@ -1,7 +1,7 @@
 ../code/conceptPage.scroll
 
 id horse64-root
-name Horse64
+name Horse64 Root
 appeared 2024
 creators Ellie Kanning-Dawn
 tags pl


### PR DESCRIPTION
Fix the name of the Horse64 Root concept, where accidentally the second part of the name was missing.