### PR TITLE
Fix workflow to not overwrite latest release on PRs (#9).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,12 +30,22 @@ jobs:
       - name: Create tarball
         run: tar czf /tmp/site.tar.gz --exclude='.git' --exclude='node_modules' --exclude='ignore' .
 
+      - name: Upload PR artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-pr-${{ github.event.pull_request.number }}
+          path: /tmp/site.tar.gz
+          retention-days: 7
+
       - name: Delete existing latest release
-        run: gh release delete latest --yes 2>/dev/null || true
+        if: github.event_name == 'push'
+        run: gh release delete latest --yes --cleanup-tag || true
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: Create latest release
+        if: github.event_name == 'push'
         run: gh release create latest /tmp/site.tar.gz --title "Latest Build" --notes "Auto-built from ${{ github.sha }}"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/test-local.sh
+++ b/test-local.sh
@@ -82,6 +82,9 @@ rm -rf "$SERVE_DIR" && mkdir -p "$SERVE_DIR"
 echo ">>> Extracting site..."
 tar xzf "$TARBALL" -C "$SERVE_DIR"
 
+echo ">>> Installing dependencies (node_modules)..."
+npm install --prefix "$SERVE_DIR"
+
 echo ""
 echo ">>> Starting server at http://localhost:${PORT}"
 echo "    Press Ctrl+C to stop"

--- a/test-local.sh
+++ b/test-local.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Test PLDB site locally using a pre-built artifact (no local rebuild needed)
+# Usage: ./test-local.sh [--pr <number>] [--repo owner/repo] [--port number]
+#
+# Without --pr: downloads and serves the latest release from main
+# With --pr:    downloads and serves the specified PR's artifact
+#
+# Requires: gh CLI authenticated, npx available
+
+set -e
+
+# Defaults
+PORT=8080
+PR_NUMBER=""
+
+# Auto-detect repo from git remote (handles both HTTPS and SSH remotes)
+REPO=$(git remote get-url origin 2>/dev/null \
+    | sed 's|https://github.com/||' \
+    | sed 's|git@github.com:||' \
+    | sed 's|\.git$||' \
+    || echo "")
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr)
+            PR_NUMBER="$2"
+            shift 2
+            ;;
+        --repo)
+            REPO="$2"
+            shift 2
+            ;;
+        --port)
+            PORT="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            echo "Usage: $0 [--pr <number>] [--repo owner/repo] [--port number]"
+            echo "Example: $0"
+            echo "Example: $0 --pr 9"
+            echo "Example: $0 --repo Programming-Language-DataBase/pldb --pr 9"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$REPO" ]; then
+    echo "ERROR: Could not detect repo from git remote. Use --repo owner/repo"
+    exit 1
+fi
+
+WORK_DIR=/tmp/pldb-local-test
+mkdir -p "$WORK_DIR"
+
+if [ -n "$PR_NUMBER" ]; then
+    echo "=== Testing PR #${PR_NUMBER} from ${REPO} ==="
+    PR_BRANCH=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefName --jq '.headRefName')
+    echo ">>> PR branch: $PR_BRANCH"
+    RUN_ID=$(gh run list --repo "$REPO" --branch "$PR_BRANCH" --event pull_request \
+        --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+    if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+        echo "ERROR: No successful workflow run found for PR #${PR_NUMBER} (branch: $PR_BRANCH)"
+        exit 1
+    fi
+    echo ">>> Run ID: $RUN_ID"
+    DOWNLOAD_DIR="$WORK_DIR/pr-${PR_NUMBER}"
+    rm -rf "$DOWNLOAD_DIR" && mkdir -p "$DOWNLOAD_DIR"
+    gh run download "$RUN_ID" --repo "$REPO" --name "site-pr-${PR_NUMBER}" --dir "$DOWNLOAD_DIR"
+    TARBALL="$DOWNLOAD_DIR/site.tar.gz"
+else
+    echo "=== Testing latest release from main (${REPO}) ==="
+    DOWNLOAD_DIR="$WORK_DIR/latest"
+    rm -rf "$DOWNLOAD_DIR" && mkdir -p "$DOWNLOAD_DIR"
+    gh release download latest --repo "$REPO" --pattern "site.tar.gz" --dir "$DOWNLOAD_DIR"
+    TARBALL="$DOWNLOAD_DIR/site.tar.gz"
+fi
+
+SERVE_DIR="$WORK_DIR/site"
+rm -rf "$SERVE_DIR" && mkdir -p "$SERVE_DIR"
+echo ">>> Extracting site..."
+tar xzf "$TARBALL" -C "$SERVE_DIR"
+
+echo ""
+echo ">>> Starting server at http://localhost:${PORT}"
+echo "    Press Ctrl+C to stop"
+echo ""
+npx serve "$SERVE_DIR" -l "$PORT"


### PR DESCRIPTION
Gate release steps on push-to-main only. PRs now upload an ephemeral artifact (site-pr-{number}, 7-day retention) instead of touching the latest release. Also add --cleanup-tag to the delete step so the git tag is removed before recreating, preventing "tag already exists" failures.

As noted by Claude:
```
❯ Is setup-pldb.sh impacted in any way?

● Read 1 file (ctrl+o to expand)

● No impact. setup-pldb.sh downloads from the latest release (line 113):

  RELEASE_URL="${REPO_URL%.git}/releases/download/latest/site.tar.gz"

  That release is only created on pushes to main — exactly as before. PRs never touch it now, so the deploy script will always find a
   clean latest release built from main. Nothing to change there.
```

I also had Claude write a Bash script that grabs the archive from Github Actions and set up a "localhost:8080". This way one can test a PR submission and see if it works.