### PR TITLE
Add Top TIOBE Languages section to homepage

### DIFF
--- a/build.js
+++ b/build.js
@@ -40,6 +40,78 @@ function runQuiet(cmd, cwd = ROOT) {
   }
 }
 
+function fetchTiobeTop10() {
+  return new Promise((resolve, reject) => {
+    const https = require('https')
+    const options = {
+      hostname: 'www.tiobe.com',
+      path: '/tiobe-index/',
+      method: 'GET',
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+      }
+    }
+    let data = ''
+    const req = https.request(options, res => {
+      res.on('data', chunk => { data += chunk })
+      res.on('end', () => {
+        // The td-top20 cell contains the language logo image; the language name
+        // is in the immediately following plain <td>.
+        const matches = [...data.matchAll(/<td class="td-top20">.*?<\/td><td>([^<]+)<\/td>/g)]
+        const top10 = matches.slice(0, 10).map(m => ({ name: m[1].trim() }))
+        if (top10.length === 0) {
+          reject(new Error('No TIOBE languages found in page — HTML structure may have changed'))
+        } else {
+          resolve(top10)
+        }
+      })
+    })
+    req.on('error', reject)
+    req.setTimeout(10000, () => { req.destroy(new Error('TIOBE fetch timed out')) })
+    req.end()
+  })
+}
+
+// Maps TIOBE display names to PLDB concept IDs
+const TIOBE_TO_PLDB = {
+  'Python': 'python',
+  'C': 'c',
+  'C++': 'cpp',
+  'Java': 'java',
+  'C#': 'csharp',
+  'JavaScript': 'javascript',
+  'Visual Basic': 'visual-basic',
+  'SQL': 'sql',
+  'R': 'r',
+  'Delphi/Object Pascal': 'delphi',
+  'Go': 'go',
+  'Fortran': 'fortran',
+  'Rust': 'rust',
+  'Kotlin': 'kotlin',
+  'Swift': 'swift',
+  'PHP': 'php',
+  'MATLAB': 'matlab',
+  'TypeScript': 'typescript',
+  'Scratch': 'scratch',
+  'Assembly language': 'assembly'
+}
+
+function writeTiobeLangsScroll(languages, fetchDate) {
+  const heading = `<p class="pldbHomepageLink"><a href="https://www.tiobe.com/tiobe-index/">Top TIOBE Languages</a> <span style="color:#828282;font-size:0.85em;">(Fetched ${fetchDate})</span></p>`
+  const items = languages.map(l => {
+    const id = TIOBE_TO_PLDB[l.name]
+    return id ? `<a href="concepts/${id}.html">${l.name}</a>` : l.name
+  })
+  const list = items.join('&nbsp;·&nbsp;')
+  const content = `importOnly
+
+${heading}
+
+${list}
+`
+  fs.writeFileSync(path.join(ROOT, 'topTiobeLangs.scroll'), content)
+}
+
 async function build() {
   const startTime = Date.now()
 
@@ -53,6 +125,17 @@ async function build() {
   // Step 2: Patch scroll-cli for Windows compatibility (if needed)
   console.log('\n🔧 Step 2: Checking scroll-cli Windows compatibility...')
   patchScrollCliIfNeeded()
+
+  // Step 2.5: Fetch TIOBE top 10 and write topTiobeLangs.scroll
+  console.log('\n📋 Step 2.5: Fetching TIOBE top 10 languages...')
+  try {
+    const tiobeLanguages = await fetchTiobeTop10()
+    const fetchDate = new Date().toISOString().split('T')[0]
+    writeTiobeLangsScroll(tiobeLanguages, fetchDate)
+    console.log(`✅ TIOBE top 10: ${tiobeLanguages.map(l => l.name).join(', ')}`)
+  } catch (err) {
+    console.warn(`⚠️  Could not fetch TIOBE data (${err.message}), keeping existing topTiobeLangs.scroll`)
+  }
 
   // Step 3: Build root folder (generates pldb.json, measures.json)
   console.log('\n📋 Step 3: Building root folder...')

--- a/build.js
+++ b/build.js
@@ -64,10 +64,10 @@ function fetchTiobeTop10() {
         // The td-top20 cell contains the language logo image; the language name
         // is in the immediately following plain <td>.
         const matches = [...data.matchAll(/<td class="td-top20">.*?<\/td><td>([^<]+)<\/td>/g)]
-        const top10 = matches.slice(0, 10).map(m => ({ name: m[1].trim() }))
-        if (top10.length === 0) {
-          reject(new Error('No TIOBE languages found in page — HTML structure may have changed'))
+        if (matches.length < 10) {
+          reject(new Error(`Expected at least 10 TIOBE languages, but found ${matches.length} — HTML structure may have changed`))
         } else {
+          const top10 = matches.slice(0, 10).map(m => ({ name: m[1].trim() }))
           resolve(top10)
         }
       })

--- a/build.js
+++ b/build.js
@@ -96,11 +96,21 @@ const TIOBE_TO_PLDB = {
   'Assembly language': 'assembly'
 }
 
+function escapeHtml(value) {
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+}
+
 function writeTiobeLangsScroll(languages, fetchDate) {
   const heading = `<p class="pldbHomepageLink"><a href="https://www.tiobe.com/tiobe-index/">Top TIOBE Languages</a> <span style="color:#828282;font-size:0.85em;">(Fetched ${fetchDate})</span></p>`
   const items = languages.map(l => {
     const id = TIOBE_TO_PLDB[l.name]
-    return id ? `<a href="concepts/${id}.html">${l.name}</a>` : l.name
+    const safeName = escapeHtml(l.name)
+    return id ? `<a href="concepts/${id}.html">${safeName}</a>` : safeName
   })
   const list = items.join('&nbsp;·&nbsp;')
   const content = `importOnly

--- a/build.js
+++ b/build.js
@@ -53,7 +53,13 @@ function fetchTiobeTop10() {
     }
     let data = ''
     const req = https.request(options, res => {
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        res.resume() // drain the response so the socket is freed
+        reject(new Error(`TIOBE fetch returned HTTP ${res.statusCode}`))
+        return
+      }
       res.on('data', chunk => { data += chunk })
+      res.on('error', reject)
       res.on('end', () => {
         // The td-top20 cell contains the language logo image; the language name
         // is in the immediately following plain <td>.

--- a/index.scroll
+++ b/index.scroll
@@ -10,6 +10,7 @@ rootHeader.scroll
 
 searchForm.scroll
 topLangs.scroll
+topTiobeLangs.scroll
 
 br 2
 

--- a/topTiobeLangs.scroll
+++ b/topTiobeLangs.scroll
@@ -1,0 +1,5 @@
+importOnly
+
+<p class="pldbHomepageLink"><a href="https://www.tiobe.com/tiobe-index/">Top TIOBE Languages</a> <span style="color:#828282;font-size:0.85em;">(Fetched 2026-04-05)</span></p>
+
+<a href="concepts/python.html">Python</a>&nbsp;·&nbsp;<a href="concepts/c.html">C</a>&nbsp;·&nbsp;<a href="concepts/cpp.html">C++</a>&nbsp;·&nbsp;<a href="concepts/java.html">Java</a>&nbsp;·&nbsp;<a href="concepts/csharp.html">C#</a>&nbsp;·&nbsp;<a href="concepts/javascript.html">JavaScript</a>&nbsp;·&nbsp;<a href="concepts/visual-basic.html">Visual Basic</a>&nbsp;·&nbsp;<a href="concepts/sql.html">SQL</a>&nbsp;·&nbsp;<a href="concepts/r.html">R</a>&nbsp;·&nbsp;<a href="concepts/delphi.html">Delphi/Object Pascal</a>


### PR DESCRIPTION
Fetches the TIOBE top 10 at build time (npm run build) and renders them on the index page beneath Top Languages, with PLDB concept links and a "(Fetched YYYY-MM-DD)" timestamp inline with the heading.

*Note, I'm adding this because I prioritize my work on Antlr4 grammars for those languages in the TIOBE list. This small change makes it easier to coordinate the changes across this and the grammars-v4 repo.*