### PR TITLE
Fix cron job not being installed when server has no existing crontab

### DIFF
--- a/setup-pldb.sh
+++ b/setup-pldb.sh
@@ -292,7 +292,7 @@ echo "    Update script installed at /root/pldb-update.sh"
 
 # Install weekly cron job (Monday 09:00 UTC)
 echo ">>> Installing weekly cron job..."
-( crontab -l 2>/dev/null | grep -v 'pldb-update'; echo '0 9 * * 1 /root/pldb-update.sh >> /root/pldb-update.log 2>&1' ) | crontab -
+( crontab -l 2>/dev/null | grep -v 'pldb-update' || true; echo '0 9 * * 1 /root/pldb-update.sh >> /root/pldb-update.log 2>&1' ) | crontab -
 echo "    Cron job installed: runs every Monday at 09:00 UTC"
 
 ENDSSH


### PR DESCRIPTION
With set -e active inside the ENDSSH heredoc, grep -v exits 1 when given empty input (no existing crontab), causing the subshell to abort before the echo runs. crontab - then receives empty stdin and installs nothing. Adding || true prevents the early exit.