### PR TITLE
Improve news page formatting and navigation

### DIFF
--- a/TrueBaseTheme.css
+++ b/TrueBaseTheme.css
@@ -1,11 +1,14 @@
 .pldbHomepageLink a {
   color: #000;
 }
+.pldbNewsHeading {
+  margin-left: 1.5em;
+}
 .pldbNewsList,
 .pldbNewsFull {
   list-style: none;
-  padding: 0;
-  margin: 0.4em 0 0.8em;
+  padding: 0 0 0 1.5em;
+  margin: 0.4em 0 0.8em 1.5em;
 }
 .pldbNewsItem {
   margin: 0.3em 0;
@@ -27,6 +30,7 @@
   color: #828282;
   font-size: 0.9em;
   margin-bottom: 1.2em;
+  text-align: center;
 }
 .newPostLink {
   line-height: 1.3em;

--- a/code/fetchLatestNews.js
+++ b/code/fetchLatestNews.js
@@ -396,10 +396,20 @@ function writeLatestNewsScroll(articles, fetchDate) {
       'Medium':              'https://medium.com/tag/programming-languages',
       'Hacker News':         'https://news.ycombinator.com',
     }
+    const ANCHORS = {
+      'arXiv cs.PL':         'arxiv-cs-pl',
+      'DBLP':                'dblp',
+      'IEEE':                'ieee',
+      'lobste.rs':           'lobsters',
+      'Lambda the Ultimate': 'lambda-the-ultimate',
+      'Medium':              'medium',
+      'Hacker News':         'hacker-news',
+    }
     const label = LABELS[src] || src
     const url = URLS[src]
+    const anchor = ANCHORS[src]
     const headingInner = url ? `<a href="${esc(url)}" target="_blank" rel="noopener">${esc(label)}</a>` : esc(label)
-    sectionsHtml += `\n<h2 class="pldbNewsHeading">${headingInner}</h2>\n<ul class="pldbNewsFull">\n`
+    sectionsHtml += `\n<h2 class="pldbNewsHeading"${anchor ? ` id="${anchor}"` : ''}>${headingInner}</h2>\n<ul class="pldbNewsFull">\n`
     sectionsHtml += items.map(articleToLi).join('\n')
     sectionsHtml += '\n</ul>\n'
   }
@@ -410,7 +420,7 @@ rootHeader.scroll
 
 # Research and News on Programming Languages
 
-<p class="pldbNewsUpdated">Updated: ${fetchDate} &nbsp;·&nbsp; Sources: <a href="https://arxiv.org/list/cs.PL/recent" target="_blank" rel="noopener">arXiv cs.PL</a> &nbsp;·&nbsp; <a href="https://dblp.org" target="_blank" rel="noopener">DBLP</a> &nbsp;·&nbsp; <a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=32" target="_blank" rel="noopener">IEEE Transactions on Software Engineering</a> &nbsp;·&nbsp; <a href="https://lobste.rs/t/plt" target="_blank" rel="noopener">lobste.rs/t/plt</a> &nbsp;·&nbsp; <a href="http://lambda-the-ultimate.org" target="_blank" rel="noopener">Lambda the Ultimate</a> &nbsp;·&nbsp; <a href="https://medium.com/tag/programming-languages" target="_blank" rel="noopener">Medium</a> &nbsp;·&nbsp; <a href="https://news.ycombinator.com" target="_blank" rel="noopener">Hacker News</a></p>
+<p class="pldbNewsUpdated">Updated: ${fetchDate} &nbsp;·&nbsp; Sources: <a href="#arxiv-cs-pl">arXiv cs.PL</a> &nbsp;·&nbsp; <a href="#dblp">DBLP</a> &nbsp;·&nbsp; <a href="#ieee">IEEE Transactions on Software Engineering</a> &nbsp;·&nbsp; <a href="#lobsters">lobste.rs/t/plt</a> &nbsp;·&nbsp; <a href="#lambda-the-ultimate">Lambda the Ultimate</a> &nbsp;·&nbsp; <a href="#medium">Medium</a> &nbsp;·&nbsp; <a href="#hacker-news">Hacker News</a></p>
 ${sectionsHtml}
 footer.scroll
 `

--- a/code/fetchLatestNews.js
+++ b/code/fetchLatestNews.js
@@ -387,8 +387,19 @@ function writeLatestNewsScroll(articles, fetchDate) {
       'DBLP':        'DBLP Computer Science Bibliography',
       'IEEE':        'IEEE Transactions on Software Engineering',
     }
+    const URLS = {
+      'arXiv cs.PL':         'https://arxiv.org/list/cs.PL/recent',
+      'DBLP':                'https://dblp.org',
+      'IEEE':                'https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=32',
+      'lobste.rs':           'https://lobste.rs/t/plt',
+      'Lambda the Ultimate': 'http://lambda-the-ultimate.org',
+      'Medium':              'https://medium.com/tag/programming-languages',
+      'Hacker News':         'https://news.ycombinator.com',
+    }
     const label = LABELS[src] || src
-    sectionsHtml += `\n<h2>${esc(label)}</h2>\n<ul class="pldbNewsFull">\n`
+    const url = URLS[src]
+    const headingInner = url ? `<a href="${url}" target="_blank" rel="noopener">${esc(label)}</a>` : esc(label)
+    sectionsHtml += `\n<h2 class="pldbNewsHeading">${headingInner}</h2>\n<ul class="pldbNewsFull">\n`
     sectionsHtml += items.map(articleToLi).join('\n')
     sectionsHtml += '\n</ul>\n'
   }
@@ -399,7 +410,7 @@ rootHeader.scroll
 
 # Research and News on Programming Languages
 
-<p class="pldbNewsUpdated">Updated: ${fetchDate} &nbsp;·&nbsp; Sources: arXiv cs.PL &nbsp;·&nbsp; DBLP &nbsp;·&nbsp; IEEE Transactions on Software Engineering &nbsp;·&nbsp; lobste.rs/t/plt &nbsp;·&nbsp; Lambda the Ultimate &nbsp;·&nbsp; Medium &nbsp;·&nbsp; Hacker News</p>
+<p class="pldbNewsUpdated">Updated: ${fetchDate} &nbsp;·&nbsp; Sources: <a href="https://arxiv.org/list/cs.PL/recent" target="_blank" rel="noopener">arXiv cs.PL</a> &nbsp;·&nbsp; <a href="https://dblp.org" target="_blank" rel="noopener">DBLP</a> &nbsp;·&nbsp; <a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=32" target="_blank" rel="noopener">IEEE Transactions on Software Engineering</a> &nbsp;·&nbsp; <a href="https://lobste.rs/t/plt" target="_blank" rel="noopener">lobste.rs/t/plt</a> &nbsp;·&nbsp; <a href="http://lambda-the-ultimate.org" target="_blank" rel="noopener">Lambda the Ultimate</a> &nbsp;·&nbsp; <a href="https://medium.com/tag/programming-languages" target="_blank" rel="noopener">Medium</a> &nbsp;·&nbsp; <a href="https://news.ycombinator.com" target="_blank" rel="noopener">Hacker News</a></p>
 ${sectionsHtml}
 footer.scroll
 `

--- a/code/fetchLatestNews.js
+++ b/code/fetchLatestNews.js
@@ -398,7 +398,7 @@ function writeLatestNewsScroll(articles, fetchDate) {
     }
     const label = LABELS[src] || src
     const url = URLS[src]
-    const headingInner = url ? `<a href="${url}" target="_blank" rel="noopener">${esc(label)}</a>` : esc(label)
+    const headingInner = url ? `<a href="${esc(url)}" target="_blank" rel="noopener">${esc(label)}</a>` : esc(label)
     sectionsHtml += `\n<h2 class="pldbNewsHeading">${headingInner}</h2>\n<ul class="pldbNewsFull">\n`
     sectionsHtml += items.map(articleToLi).join('\n')
     sectionsHtml += '\n</ul>\n'


### PR DESCRIPTION
Fix for #29.

- Indent news section headings 1.5em and list items an additional 1.5em
- Link section headings and Sources line to each source's main website
- Center the "Updated:" metadata line